### PR TITLE
Moved to git repo for stock module. Fixes :

### DIFF
--- a/modules/stocks/index.js
+++ b/modules/stocks/index.js
@@ -53,7 +53,7 @@ function getStock(p, reply) {
   exchange = aliases.exchange[exchange] || exchange;
   stock = aliases.stock[stock] || stock;
 
-  ss.stockscraper(exchange, stock, function(err,res) {
+  ss.scrape(exchange, stock, function(err,res) {
     if(err) {
       reply('Error getting stock data');
       return;

--- a/modules/stocks/package.json
+++ b/modules/stocks/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "",
   "dependencies": {
-    "stockscraper": "latest"
+    "stockscraper": "git://github.com/brhoades/stockscraper#master"
   },
   "main": "index.js",
   "author": "",


### PR DESCRIPTION
Moved to a forked git repo which has the latest version of stockscraper. This has a few syntatic differences, but overall functions the same. The perk is that : no longer crashes the bot.
